### PR TITLE
furl.html: PBKDF2 PIN derivation (versioned, SHA-256 fallback)

### DIFF
--- a/web/furl.html
+++ b/web/furl.html
@@ -522,20 +522,34 @@
 
                 let fileDecryptionKey, ivOrNonce;
 
+                // Derive the PIN-wrapping key from the PIN + salt. New shares
+                // set kdf = 'pbkdf2-sha256-600000' and use PBKDF2 (slow, brute-
+                // force resistant); shares created before that field fall back
+                // to the original single SHA-256 so existing links still open.
+                const derivePinKeyBuffer = async (pin, salt) => {
+                    const pinBytes = new TextEncoder().encode(pin);
+                    if (secrets.kdf === 'pbkdf2-sha256-600000') {
+                        const baseKey = await window.crypto.subtle.importKey(
+                            'raw', pinBytes, 'PBKDF2', false, ['deriveBits']);
+                        return await window.crypto.subtle.deriveBits(
+                            { name: 'PBKDF2', hash: 'SHA-256', salt: salt, iterations: 600000 },
+                            baseKey, 256);
+                    }
+                    // Legacy: SHA-256(PIN || salt)
+                    const combined = new Uint8Array(pinBytes.length + salt.byteLength);
+                    combined.set(new Uint8Array(pinBytes));
+                    combined.set(new Uint8Array(salt), pinBytes.length);
+                    return await window.crypto.subtle.digest('SHA-256', combined);
+                };
+
                 if (cipherType === 'chacha20') {
                     setStatus('Decrypting ChaCha20 key with your PIN...');
                     
                     const salt = base64ToArrayBuffer(secrets.key_salt);
-                    const pinBytes = new TextEncoder().encode(pin);
-                    
-                    // Create combined bytes for key derivation (PIN + salt)
-                    const combinedBytes = new Uint8Array(pinBytes.length + salt.byteLength);
-                    combinedBytes.set(new Uint8Array(pinBytes));
-                    combinedBytes.set(new Uint8Array(salt), pinBytes.length);
-                    
-                    // Hash with SHA-256 to match Dart implementation
-                    const pinKeyArrayBuffer = await window.crypto.subtle.digest('SHA-256', combinedBytes);
-                    
+
+                    // Derive the PIN-wrapping key (PBKDF2 for new shares, SHA-256 for old).
+                    const pinKeyArrayBuffer = await derivePinKeyBuffer(pin, salt);
+
                     // Import PIN key for AES-CTR decryption of ChaCha20 key
                     const pinKey = await window.crypto.subtle.importKey(
                         'raw',
@@ -582,16 +596,10 @@
                     setStatus('Decrypting AES key with your PIN...');
                     
                     const salt = base64ToArrayBuffer(secrets.aes_key_salt || secrets.key_salt);
-                    const pinBytes = new TextEncoder().encode(pin);
-                    
-                    // Create combined bytes for key derivation (PIN + salt)
-                    const combinedBytes = new Uint8Array(pinBytes.length + salt.byteLength);
-                    combinedBytes.set(new Uint8Array(pinBytes));
-                    combinedBytes.set(new Uint8Array(salt), pinBytes.length);
-                    
-                    // Hash with SHA-256 to match Dart implementation
-                    const pinKeyArrayBuffer = await window.crypto.subtle.digest('SHA-256', combinedBytes);
-                    
+
+                    // Derive the PIN-wrapping key (PBKDF2 for new shares, SHA-256 for old).
+                    const pinKeyArrayBuffer = await derivePinKeyBuffer(pin, salt);
+
                     // Import PIN key for AES-CTR decryption
                     const pinKey = await window.crypto.subtle.importKey(
                         'raw',


### PR DESCRIPTION
## What

Adds support for PBKDF2-based PIN key derivation in the web decrypt client, gated on a new `kdf` field in the share metadata, with a transparent fallback to the existing single SHA-256 for older links.

## Why

The PIN-wrapping key is currently derived with a single `SHA-256(PIN || salt)`. With a ~52-bit PIN that's cheap to brute-force offline if a share link leaks (an attacker who has the link can fetch the public atKey metadata + the ciphertext and grind PINs at GPU/ASIC speed). `SECURITY_DESIGN.md` already flags PBKDF2/Argon2 as the intended hardening. PBKDF2 at 600k iterations raises per-guess cost by ~6 orders of magnitude.

## How

- New helper `derivePinKeyBuffer(pin, salt)` used by both the ChaCha20 and legacy AES-CTR key-unwrap paths.
- If `secrets.kdf === 'pbkdf2-sha256-600000'` → derive with PBKDF2-HMAC-SHA256, 600k iterations via WebCrypto (`deriveBits`).
- Otherwise → original single SHA-256, so **every existing link keeps working**.
- No WASM change — WebCrypto does PBKDF2 natively; only the KDF step changed, the AES-CTR unwrap and ChaCha20 file decryption are untouched.

## Sender side

This pairs with the atmospherePro app change that derives the PIN key with the same PBKDF2 parameters and stamps `"kdf": "pbkdf2-sha256-600000"` into the metadata.

**Deploy order:** this page change is backward-compatible and should go live first; the app change ships after. (Reverse order would break new links until the page is updated.)

## Verification

Round-trip verified outside the browser: a key wrapped with PBKDF2 + AES-256-CTR (sender params) unwraps correctly via this page's WebCrypto PBKDF2 + AES-CTR path, and the derived keys are byte-equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)